### PR TITLE
CI: test on Py3.9+

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,6 +19,10 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
         environment-file: [ci/latest.yaml]
         include:
+          - environment-file: ci/39.yaml
+            os: ubuntu-latest
+          - environment-file: ci/310.yaml
+            os: ubuntu-latest
           - environment-file: ci/dev.yaml
             os: ubuntu-latest
     defaults:

--- a/ci/310.yaml
+++ b/ci/310.yaml
@@ -2,7 +2,7 @@ name: xvec
 channels:
   - conda-forge
 dependencies:
-  - python
+  - python=3.10
   # required
   - shapely=2
   - xarray

--- a/ci/39.yaml
+++ b/ci/39.yaml
@@ -2,7 +2,7 @@ name: xvec
 channels:
   - conda-forge
 dependencies:
-  - python
+  - python=3.9
   # required
   - shapely=2
   - xarray

--- a/ci/dev.yaml
+++ b/ci/dev.yaml
@@ -1,7 +1,6 @@
 name: xvec_dev
 channels:
   - conda-forge
-  - conda-forge/label/shapely_dev
 dependencies:
   - python
   # to build from source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering :: GIS",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "xarray >= 2022.12.0",
     "pyproj >= 3.0.0",
@@ -55,4 +55,4 @@ exclude_lines = [
 line-length = 88
 select = ["E", "F", "W", "I", "UP", "B", "A", "C4", "Q"]
 exclude = ["doc"]
-target-version = "py38"
+target-version = "py39"

--- a/xvec/accessor.py
+++ b/xvec/accessor.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import warnings
-from typing import Any, Hashable, Mapping, Sequence, Union
+from typing import Any, Hashable, Mapping, Sequence
 
 import numpy as np
 import pandas as pd
@@ -18,7 +20,7 @@ class XvecAccessor:
     Currently works on coordinates with :class:`xvec.GeometryIndex`.
     """
 
-    def __init__(self, xarray_obj: Union[xr.Dataset, xr.DataArray]):
+    def __init__(self, xarray_obj: xr.Dataset | xr.DataArray):
         """xvec init, nothing to be done here."""
         self._obj = xarray_obj
         self._geom_coords_all = [

--- a/xvec/accessor.py
+++ b/xvec/accessor.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, Hashable, Mapping, Sequence
+from collections.abc import Hashable, Mapping, Sequence
+from typing import Any
 
 import numpy as np
 import pandas as pd

--- a/xvec/index.py
+++ b/xvec/index.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, Hashable, Iterable, Mapping, Sequence
+from collections.abc import Hashable, Iterable, Mapping, Sequence
+from typing import Any
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
Adding Python 3.9 and 3.10 to the CI matrix. Not including 3.8 based on SPEC0 (https://scientific-python.org/specs/spec-0000/) which is almost the same as NEP29, which would drop 3.8 in April.

Closes #34 