### PR TITLE
use float32 as mask in rasterize

### DIFF
--- a/xvec/zonal.py
+++ b/xvec/zonal.py
@@ -60,6 +60,7 @@ def _zonal_stats_rasterize(
         transform=transform,
         fill=np.nan,  # type: ignore
         all_touched=all_touched,
+        dtype=np.float32,
     )
     groups = acc._obj.groupby(xr.DataArray(labels, dims=(y_coords, x_coords)))
 


### PR DESCRIPTION
We certainly don't need to create the mask as float64. To keep the missing values masked using np.nan, switching only to float32. We could, in theory, use something like int16 but then we would need to map missing values to -1 or something and treat them later. If we do that before passing to the groupby, then we need a `where` mask resulting in another float32 array (once masked), so there's no point. We could also remove -1 after groupby but then we're doing aggregation on stuff we don't care about. So let's stick with float32 for now.

Closes #76 