### PR TITLE
Addition of strategy argument for exact extract

### DIFF
--- a/xvec/tests/test_zonal_stats.py
+++ b/xvec/tests/test_zonal_stats.py
@@ -425,3 +425,34 @@ def test_variable_geometry_single(glaciers):
 
     assert result.sizes == {"year": 3, "name": 5, "band": 11}
     assert result.statistics.mean() == 13168.585
+
+
+def test_exactextract_strategy():
+    ds = xr.tutorial.open_dataset("eraint_uvz")
+    world = gpd.read_file(geodatasets.get_path("naturalearth land"))
+
+    result_feature_sequential = ds.z.xvec.zonal_stats(
+        world.geometry,
+        "longitude",
+        "latitude",
+        method="exactextract",
+        strategy="feature-sequential",
+    )
+    result_raster_sequential = ds.z.xvec.zonal_stats(
+        world.geometry,
+        "longitude",
+        "latitude",
+        method="exactextract",
+        strategy="raster-sequential",
+    )
+
+    xr.testing.assert_allclose(result_feature_sequential, result_raster_sequential)
+
+    with pytest.raises(KeyError):
+        ds.z.xvec.zonal_stats(
+            world.geometry,
+            "longitude",
+            "latitude",
+            method="exactextract",
+            strategy="invalid_strategy",
+        )

--- a/xvec/zonal.py
+++ b/xvec/zonal.py
@@ -309,6 +309,7 @@ def _zonal_stats_exactextract(
     y_coords: Hashable,
     stats: str | Callable | Sequence[str | Callable | tuple] = "mean",
     name: str = "geometry",
+    strategy: str = "feature-sequential"
 ) -> xr.DataArray | xr.Dataset:
     """Extract the values from a dataset indexed by a set of geometries
 
@@ -363,7 +364,7 @@ def _zonal_stats_exactextract(
                 raise ValueError(f"{stat} is not a valid aggregation.")
 
         results, original_shape, coords_info, locs = _agg_exactextract(
-            acc, geometry, crs, x_coords, y_coords, stats, name, original_is_ds
+            acc, geometry, crs, x_coords, y_coords, stats, name, original_is_ds, strategy
         )
         i = 0
         for stat in stats:  # type: ignore
@@ -393,7 +394,7 @@ def _zonal_stats_exactextract(
         )
     elif isinstance(stats, str):
         results, original_shape, coords_info, _ = _agg_exactextract(
-            acc, geometry, crs, x_coords, y_coords, stats, name, original_is_ds
+            acc, geometry, crs, x_coords, y_coords, stats, name, original_is_ds, strategy
         )
         # Unstack the result
         arr = results.values.reshape(original_shape)
@@ -429,6 +430,7 @@ def _agg_exactextract(
     stats: str | Callable | Iterable[str | Callable | tuple] = "mean",
     name: str = "geometry",
     original_is_ds: bool = False,
+    strategy: str = "feature-sequential"
 ):
     """Extract the values from a dataset indexed by a set of geometries
 
@@ -492,7 +494,7 @@ def _agg_exactextract(
 
     # Aggregation result
     gdf = gpd.GeoDataFrame(geometry=geometry, crs=crs)
-    results = exactextract.exact_extract(rast=data, vec=gdf, ops=stats, output="pandas")
+    results = exactextract.exact_extract(rast=data, vec=gdf, ops=stats, output="pandas", strategy=strategy)
     # Get all the dimensions execpt x_coords, y_coords, they will be used to stack the
     # dataarray later
     if original_is_ds is True:

--- a/xvec/zonal.py
+++ b/xvec/zonal.py
@@ -309,7 +309,7 @@ def _zonal_stats_exactextract(
     y_coords: Hashable,
     stats: str | Callable | Sequence[str | Callable | tuple] = "mean",
     name: str = "geometry",
-    strategy: str = "feature-sequential"
+    strategy: str = "feature-sequential",
 ) -> xr.DataArray | xr.Dataset:
     """Extract the values from a dataset indexed by a set of geometries
 
@@ -367,7 +367,15 @@ def _zonal_stats_exactextract(
                 raise ValueError(f"{stat} is not a valid aggregation.")
 
         results, original_shape, coords_info, locs = _agg_exactextract(
-            acc, geometry, crs, x_coords, y_coords, stats, name, original_is_ds, strategy
+            acc,
+            geometry,
+            crs,
+            x_coords,
+            y_coords,
+            stats,
+            name,
+            original_is_ds,
+            strategy,
         )
         i = 0
         for stat in stats:  # type: ignore
@@ -397,7 +405,15 @@ def _zonal_stats_exactextract(
         )
     elif isinstance(stats, str):
         results, original_shape, coords_info, _ = _agg_exactextract(
-            acc, geometry, crs, x_coords, y_coords, stats, name, original_is_ds, strategy
+            acc,
+            geometry,
+            crs,
+            x_coords,
+            y_coords,
+            stats,
+            name,
+            original_is_ds,
+            strategy,
         )
         # Unstack the result
         arr = results.values.reshape(original_shape)
@@ -433,7 +449,7 @@ def _agg_exactextract(
     stats: str | Callable | Iterable[str | Callable | tuple] = "mean",
     name: str = "geometry",
     original_is_ds: bool = False,
-    strategy: str = "feature-sequential"
+    strategy: str = "feature-sequential",
 ):
     """Extract the values from a dataset indexed by a set of geometries
 
@@ -500,7 +516,9 @@ def _agg_exactextract(
 
     # Aggregation result
     gdf = gpd.GeoDataFrame(geometry=geometry, crs=crs)
-    results = exactextract.exact_extract(rast=data, vec=gdf, ops=stats, output="pandas", strategy=strategy)
+    results = exactextract.exact_extract(
+        rast=data, vec=gdf, ops=stats, output="pandas", strategy=strategy
+    )
     # Get all the dimensions execpt x_coords, y_coords, they will be used to stack the
     # dataarray later
     if original_is_ds is True:

--- a/xvec/zonal.py
+++ b/xvec/zonal.py
@@ -334,6 +334,9 @@ def _zonal_stats_exactextract(
         ``"quantile(q=0.20)"``)
     name : str, optional
         Name of the dimension that will hold the ``geometry``, by default "geometry"
+    strategy : str, optional
+        The strategy to use for the extraction, by default "feature-sequential"
+        Use either "feature-sequential" and "raster-sequential".
 
     Returns
     -------
@@ -460,6 +463,9 @@ def _agg_exactextract(
         If True, all pixels touched by geometries will be considered. If False, only
         pixels whose center is within the polygon or that are selected by
         Bresenham’s line algorithm will be considered.
+    strategy : str, optional
+        The strategy to use for the extraction, by default "feature-sequential"
+        Use either "feature-sequential" and "raster-sequential".
 
     Returns
     -------

--- a/xvec/zonal.py
+++ b/xvec/zonal.py
@@ -309,7 +309,7 @@ def _zonal_stats_exactextract(
     y_coords: Hashable,
     stats: str | Callable | Sequence[str | Callable | tuple] = "mean",
     name: str = "geometry",
-    strategy: str = "feature-sequential",
+    **kwargs,
 ) -> xr.DataArray | xr.Dataset:
     """Extract the values from a dataset indexed by a set of geometries
 
@@ -334,9 +334,6 @@ def _zonal_stats_exactextract(
         ``"quantile(q=0.20)"``)
     name : str, optional
         Name of the dimension that will hold the ``geometry``, by default "geometry"
-    strategy : str, optional
-        The strategy to use for the extraction, by default "feature-sequential"
-        Use either "feature-sequential" and "raster-sequential".
 
     Returns
     -------
@@ -375,7 +372,7 @@ def _zonal_stats_exactextract(
             stats,
             name,
             original_is_ds,
-            strategy,
+            **kwargs,
         )
         i = 0
         for stat in stats:  # type: ignore
@@ -413,7 +410,7 @@ def _zonal_stats_exactextract(
             stats,
             name,
             original_is_ds,
-            strategy,
+            **kwargs,
         )
         # Unstack the result
         arr = results.values.reshape(original_shape)


### PR DESCRIPTION
- Allows for the specification of "strategy" when using exact extract
- The exact differences about this strategy are listed [here](https://isciences.github.io/exactextract/performance.html#processing-strategies)
- In our use case we observe order of magnitude differences between feature/raster-sequential especially when pulling rasters over the network we saw times drastically decrease from 1 hour to ~60 seconds due to chunks being read many times

- Aside from updates here, please let me know if you want additional changes to docs/alternative implementation, I'm personally using this branch internally, so will be quick to update.
