### PR TITLE
XProj integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "pyproj >= 3.0.0",
     "shapely >= 2.0b1",
     "cf_xarray >= 0.9.2",
+    "xproj >= 0.2.0",
 ]
 
 [project.optional-dependencies]

--- a/xvec/index.py
+++ b/xvec/index.py
@@ -7,46 +7,14 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import shapely
+import xproj
 from pyproj import CRS
 from xarray import DataArray, Variable, get_options
 from xarray.core.indexing import IndexSelResult
 from xarray.indexes import Index, PandasIndex
 
 
-def _format_crs(crs: CRS | None, max_width: int = 50) -> str:
-    if crs is not None:
-        srs = crs.to_string()
-    else:
-        srs = "None"
-
-    return srs if len(srs) <= max_width else " ".join([srs[:max_width], "..."])
-
-
-def _get_common_crs(crs_set: set[CRS | None]) -> CRS | None:
-    # code taken from geopandas (BSD-3 Licence)
-
-    crs_not_none = [crs for crs in crs_set if crs is not None]
-    names = [crs.name for crs in crs_not_none]
-
-    if len(crs_not_none) == 0:
-        return None
-    if len(crs_not_none) == 1:
-        if len(crs_set) != 1:
-            warnings.warn(  # noqa: B028
-                "CRS not set for some of the concatenation inputs. "
-                f"Setting output's CRS as {names[0]} "
-                "(the single non-null CRS provided).",
-                stacklevel=3,
-            )
-        return crs_not_none[0]
-
-    raise ValueError(
-        f"cannot determine common CRS for concatenation inputs, got {names}. "
-        # "Use `to_crs()` to transform geometries to the same CRS before merging."
-    )
-
-
-class GeometryIndex(Index):
+class GeometryIndex(Index, xproj.ProjIndexMixin):
     """An CRS-aware, Xarray-compatible index for vector geometries.
 
     This index can be set from any 1-dimensional coordinate of
@@ -99,25 +67,14 @@ class GeometryIndex(Index):
             self._sindex = shapely.STRtree(self._index.index)
         return self._sindex
 
-    def _check_crs(self, other_crs: CRS | None, allow_none: bool = False) -> bool:
-        """Check if the index's projection is the same than the given one.
-        If allow_none is True, empty CRS is treated as the same.
-        """
-        if allow_none:
-            if self.crs is None or other_crs is None:
-                return True
-        if not self.crs == other_crs:
-            return False
-        return True
-
     def _crs_mismatch_raise(
         self, other_crs: CRS | None, warn: bool = False, stacklevel: int = 3
     ) -> None:
         """Raise a CRS mismatch error or warning with the information
         on the assigned CRS.
         """
-        srs = _format_crs(self.crs, max_width=50)
-        other_srs = _format_crs(other_crs, max_width=50)
+        srs = xproj.format_crs(self.crs, max_width=50)
+        other_srs = xproj.format_crs(other_crs, max_width=50)
 
         # TODO: expand message with reproject suggestion
         msg = (
@@ -152,7 +109,7 @@ class GeometryIndex(Index):
         positions: Iterable[Iterable[int]] | None = None,
     ) -> GeometryIndex:
         crs_set = {idx.crs for idx in indexes}
-        crs = _get_common_crs(crs_set)
+        crs = xproj.get_common_crs(crs_set)
 
         indexes_ = [idx._index for idx in indexes]
         index = PandasIndex.concat(indexes_, dim, positions)
@@ -232,14 +189,14 @@ class GeometryIndex(Index):
     ) -> bool:
         if not isinstance(other, GeometryIndex):
             return False
-        if not self._check_crs(other.crs, allow_none=True):
+        if not self._proj_crs_equals(other, allow_none=True):
             return False
         return self._index.equals(other._index, exclude=exclude)
 
     def join(
         self: GeometryIndex, other: GeometryIndex, how: str = "inner"
     ) -> GeometryIndex:
-        if not self._check_crs(other.crs, allow_none=True):
+        if not self._proj_crs_equals(other, allow_none=True):
             self._crs_mismatch_raise(other.crs)
 
         index = self._index.join(other._index, how=how)
@@ -251,7 +208,7 @@ class GeometryIndex(Index):
         method: str | None = None,
         tolerance: int | float | Iterable[int | float] | None = None,
     ) -> dict[Hashable, Any]:
-        if not self._check_crs(other.crs, allow_none=True):
+        if not self._proj_crs_equals(other, allow_none=True):
             self._crs_mismatch_raise(other.crs)
 
         return self._index.reindex_like(
@@ -273,11 +230,11 @@ class GeometryIndex(Index):
         if max_width is None:
             max_width = get_options()["display_width"]
 
-        srs = _format_crs(self.crs, max_width=max_width)
+        srs = xproj.format_crs(self.crs, max_width=max_width)
         return f"{self.__class__.__name__} (crs={srs})"
 
     def __repr__(self) -> str:
-        srs = _format_crs(self.crs)
+        srs = xproj.format_crs(self.crs)
         shape = self._index.index.shape[0]
         if shape == 0:
             return f"GeometryIndex([], crs={srs})"

--- a/xvec/plotting.py
+++ b/xvec/plotting.py
@@ -4,14 +4,8 @@ from typing import Any
 import numpy as np
 import shapely
 import xarray as xr
+import xproj  # noqa: F401
 from xarray.plot.utils import _determine_cmap_params, label_from_attrs
-
-try:
-    import xproj  # noqa: F401
-
-    HAS_XPROJ = True
-except ImportError:
-    HAS_XPROJ = False
 
 
 def _setup_axes(n_rows, n_cols, arr, geometry, crs, subplot_kws, figsize):
@@ -67,15 +61,9 @@ def _get_crs(arr, geometry=None):
         if geometry:
             return arr[geometry].crs
         elif np.all(shapely.is_valid_input(arr.data)):
-            return arr.proj.crs if HAS_XPROJ else None
+            return arr.proj.crs
         return arr.xindexes[list(arr.xvec._geom_coords_all)[0]].crs
-    return (
-        arr[geometry].crs
-        if hasattr(arr[geometry], "crs")
-        else arr.proj.crs
-        if HAS_XPROJ
-        else None
-    )
+    return arr[geometry].crs if hasattr(arr[geometry], "crs") else arr.proj.crs
 
 
 def _setup_legend(fig, cmap_params, label=None):

--- a/xvec/tests/test_index.py
+++ b/xvec/tests/test_index.py
@@ -51,9 +51,7 @@ def test_concat(geom_dataset, geom_array, geom_dataset_no_index, geom_dataset_no
     xr.testing.assert_identical(actual, expected)
 
     # mixed CRS / no CRS
-    with pytest.warns(
-        UserWarning, match="CRS not set for some of the concatenation inputs"
-    ):
+    with pytest.warns(UserWarning, match="CRS is undefined for some of the inputs"):
         xr.concat([geom_dataset, geom_dataset_no_crs], "geom")
 
 

--- a/xvec/tests/test_xproj_integration.py
+++ b/xvec/tests/test_xproj_integration.py
@@ -1,0 +1,26 @@
+import shapely
+import xproj  # noqa: F401
+
+
+def test_xproj_crs(geom_dataset):
+    assert geom_dataset.xindexes["geom"].crs.equals(geom_dataset.proj("geom").crs)
+
+
+def test_xproj_map_crs(geom_dataset_no_crs):
+    ds_with_crsindex = geom_dataset_no_crs.proj.assign_crs(spatial_ref=26915)
+
+    # set crs
+    ds = ds_with_crsindex.proj.map_crs(spatial_ref=["geom"])
+    assert ds.proj("geom").crs.equals(ds.proj("spatial_ref").crs)
+
+    # to crs
+    geom_array_4326 = shapely.from_wkt(
+        ["POINT (-97.488735 0.000018)", "POINT (-97.488717 0.000036)"]
+    )
+
+    ds_with_crsindex2 = ds.proj.assign_crs(spatial_ref=4326, allow_override=True)
+    ds2 = ds_with_crsindex2.proj.map_crs(
+        spatial_ref=["geom"], transform=True, allow_override=True
+    )
+    assert ds2.proj("geom").crs.equals(ds2.proj("spatial_ref").crs)
+    assert shapely.equals_exact(geom_array_4326, ds2.geom, tolerance=1e-5).all()

--- a/xvec/utils.py
+++ b/xvec/utils.py
@@ -1,0 +1,29 @@
+import numpy as np
+import shapely
+from pyproj import CRS, Transformer
+
+
+def transform_geom(array: np.ndarray, crs_from: CRS, crs_to: CRS) -> np.ndarray:
+    # transformation code taken from geopandas (BSD 3-clause license)
+    if crs_from.is_exact_same(crs_to):
+        return np.asarray(array)
+
+    transformer = Transformer.from_crs(crs_from, crs_to, always_xy=True)
+
+    has_z = shapely.has_z(array)
+
+    result = np.empty_like(array)
+
+    coordinates = shapely.get_coordinates(array[~has_z], include_z=False)
+    new_coords = transformer.transform(coordinates[:, 0], coordinates[:, 1])
+    result[~has_z] = shapely.set_coordinates(
+        array[~has_z].copy(), np.array(new_coords).T
+    )
+
+    coords_z = shapely.get_coordinates(array[has_z], include_z=True)
+    new_coords_z = transformer.transform(coords_z[:, 0], coords_z[:, 1], coords_z[:, 2])
+    result[has_z] = shapely.set_coordinates(
+        array[has_z].copy(), np.array(new_coords_z).T
+    )
+
+    return result


### PR DESCRIPTION
This PR integrates `xvec` with `xproj` (see https://github.com/xarray-contrib/xproj/pull/27 for more context).

From the Xvec's user point of view there's no change, apart from:

- `xproj` becoming a required dependency
- some subtle differences in a couple of warning or error messages
- a possible error raised instead of setting an undefined CRS (None) when Xproj finds multiple distinct CRSs in an Xarray Dataset or DataArray (this may be an edge case where raising an error may actually make more sense)

There's a few more details in the commit messages.

I added a couple of tests in `test_xproj_integration.py`, which illustrate how `xvec` and `xproj` may be used together. I can also add those examples in the documentation, although maybe it'd be safer to wait a bit until `xproj` becomes a bit more mature? I plan to add similar examples in `xproj`'s documentation anyway.

