### PR TITLE
add rioxarray and exactextract to dev environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,9 +4,11 @@ channels:
 dependencies:
   - python
   # required
-  - shapely=2
+  - shapely >=2
   - xarray
   - cf_xarray
+  - rioxarray
+  - exactextract
   # testing
   - pytest
   - pytest-cov


### PR DESCRIPTION
Hi @martinfleis, while I was trying to setup a dev environment to reproduce the fails in the CI/CD, I have realized that `environment.yml` and `ci.yml` files were out of sync. With the previous `environment.yml`, it was not possible to run the pytestt. now it also includes rioxarray and exactextract

```zsh
(xvec_dev) baris@laptop043 ~/dev/xvec (main) $ pytest
========================================================================================= test session starts ==========================================================================================
platform linux -- Python 3.14.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/baris/dev/xvec
configfile: pyproject.toml
plugins: xdist-3.8.0, cov-7.0.0
collected 122 items / 1 error                                                                                                                                                                          

================================================================================================ ERRORS ================================================================================================
___________________________________________________________________________ ERROR collecting xvec/tests/test_zonal_stats.py ____________________________________________________________________________
ImportError while importing test module '/home/baris/dev/xvec/xvec/tests/test_zonal_stats.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../anaconda3/envs/xvec_dev/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
xvec/tests/test_zonal_stats.py:6: in <module>
    import rioxarray
E   ModuleNotFoundError: No module named 'rioxarray'
======================================================================================= short test summary info ========================================================================================
ERROR xvec/tests/test_zonal_stats.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
=========================================================================================== 1 error in 0.64s ===========================================================================================
